### PR TITLE
Adopting the right mindset of Atomic Design, Redux, and Storybook

### DIFF
--- a/src/components/atoms/Button/index.stories.ts
+++ b/src/components/atoms/Button/index.stories.ts
@@ -2,25 +2,18 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { Button } from './index';
 import { MINUS, PLUS, RESET } from '../../../common/constant';
 
-
-// More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 const meta = {
   title: 'Counter/Atoms/Button',
   component: Button,
   parameters: {
-    // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/react/configure/story-layout
     layout: 'centered',
   },
-  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/react/writing-docs/autodocs
   tags: ['autodocs'],
-  // More on argTypes: https://storybook.js.org/docs/react/api/argtypes
   argTypes: {},
 } satisfies Meta<typeof Button>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
-
-// More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
 
 export const SmGray: Story = {
   args: {

--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -1,25 +1,22 @@
 interface ButtonProps {
 	/**
-		* What background color to use
+		* ボタンの背景色
 		*/
 	bgColor?: 'red' | 'blue' | 'green' | 'gray';
 	/**
-	 * How large should the button be?
+	 * ボタンの大きさ
 	 */
 	size?: 'sm' | 'md' | 'lg';
 	/**
-	 * Button contents
+	 * ボタンのラベル
 	 */
 	label: string;
 	/**
-	 * Optional click handler
+	 * ボタン押下時のイベント
 	 */
 	onClick?: () => void;
 }
 
-/**
- * Primary UI component for user interaction
- */
 export const Button = ({
 	bgColor = 'gray',
 	size = 'md',

--- a/src/components/molecules/Buttons/index.stories.ts
+++ b/src/components/molecules/Buttons/index.stories.ts
@@ -1,25 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { Buttons } from './index';
 
-
-// More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 const meta = {
   title: 'Counter/Molecules/Button',
   component: Buttons,
   parameters: {
-    // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/react/configure/story-layout
     layout: 'centered',
   },
-  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/react/writing-docs/autodocs
   tags: ['autodocs'],
-  // More on argTypes: https://storybook.js.org/docs/react/api/argtypes
   argTypes: {},
 } satisfies Meta<typeof Buttons>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-// More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
 export const CountButtons: Story = {
   args: {},
 };

--- a/src/components/molecules/Buttons/index.tsx
+++ b/src/components/molecules/Buttons/index.tsx
@@ -2,18 +2,18 @@ import { MINUS, PLUS, RESET } from "../../../common/constant";
 import { Button } from "../../atoms/Button";
 
 interface ButtonsProps {
-	/**
-	 * plus button click handler
-	 */
-	plusBtnClick?: () => void;
-  	/**
-	 * minus button click handler
-	 */
-	minusBtnClick?: () => void;
-    	/**
-	 * reset button click handler
-	 */
-	resetBtnClick?: () => void;
+  /**
+   * ＋ボタン押下時のイベント
+   */
+  plusBtnClick?: () => void;
+  /**
+ 　* ーボタン押下時のイベント
+ 　*/
+  minusBtnClick?: () => void;
+  /**
+　 * ↺ボタン押下時のイベント
+　 */
+  resetBtnClick?: () => void;
 }
 
 export const Buttons = ({...props}: ButtonsProps) => {

--- a/src/components/organisms/Counter/index.tsx
+++ b/src/components/organisms/Counter/index.tsx
@@ -1,30 +1,33 @@
-import { useDispatch, useSelector } from "react-redux";
-
-import { loadCurrentCount } from "../../../reducks/counters/selectors";
-import { RootState } from "../../../reducks/store";
-import { decrease, increase, reset } from "../../../reducks/counters/slices";
-
 import { Buttons } from "../../molecules/Buttons";
 
 import { COUNT } from "../../../common/constant";
 
-export const Counter = () => {
-  const selector = useSelector((state: RootState) => state)
-  const count = loadCurrentCount(selector)
+interface CounterAreaProps {
+  /**
+   * 現在のカウント
+   */
+  count: number;
+  /**
+   * ＋ボタン押下時のイベント
+   */
+  plusBtnClick?: () => void;
+  /**
+ 　* ーボタン押下時のイベント
+ 　*/
+  minusBtnClick?: () => void;
+  /**
+　* ↺ボタン押下時のイベント
+　*/
+  resetBtnClick?: () => void;
+}
 
-  const dispatch = useDispatch()
-
-  const plusBtnClick = () => dispatch(increase())
-  const minusBtnClick = () => dispatch(decrease())
-  const resetBtnClick = () => dispatch(reset())
-
-  const props = { plusBtnClick, minusBtnClick, resetBtnClick}
+export const Counter = (props: CounterAreaProps) => {
 
   return (
     <div className="flex flex-col items-center lg:p-36 md:p-24 sm:p-12 ">
       <div className="grid grid-col-12 gap-4 text-xl p-20">
         <div className="col-start-2 col-end-6">{COUNT}</div>
-        <div className="col-start-7 col-end-11">{count}</div>
+        <div className="col-start-7 col-end-11">{props.count}</div>
       </div>
       <Buttons {...props} />
     </div>

--- a/src/components/organisms/Header/index.stories.ts
+++ b/src/components/organisms/Header/index.stories.ts
@@ -2,25 +2,19 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { Header } from './index';
 import { APP_NAME } from '../../../common/constant';
 
-
-// More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 const meta = {
   title: 'Counter/Organisms/Header',
   component: Header,
   parameters: {
-    // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/react/configure/story-layout
     layout: 'centered',
   },
-  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/react/writing-docs/autodocs
   tags: ['autodocs'],
-  // More on argTypes: https://storybook.js.org/docs/react/api/argtypes
   argTypes: {},
 } satisfies Meta<typeof Header>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-// More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
 export const Blue: Story = {
   args: {
     title: APP_NAME,

--- a/src/components/organisms/Header/index.tsx
+++ b/src/components/organisms/Header/index.tsx
@@ -1,5 +1,11 @@
 interface HeaderProps {
+	  /**
+   * ヘッダータイトル
+   */
 	title: string;
+	  /**
+   * ヘッダーの背景色
+   */
 	bgColor?: 'white' | 'gray' | 'blue'
 }
 

--- a/src/components/pages/top/index.tsx
+++ b/src/components/pages/top/index.tsx
@@ -1,14 +1,25 @@
 import React from 'react';
-import { Header } from '../../organisms/Header';
-import { Counter as CountArea } from '../../organisms/Counter';
-import { APP_NAME } from '../../../common/constant';
+
+import { useDispatch, useSelector } from 'react-redux';
+import { loadCurrentCount } from '../../../reducks/counters/selectors';
+import { RootState } from '../../../reducks/store';
+import { decrease, increase, reset } from '../../../reducks/counters/slices';
+import { CounterTop } from '../../templates/top';
 
 const CounterApp: React.FC = () => {
+
+  const selector = useSelector((state: RootState) => state)
+  const count = loadCurrentCount(selector)
+
+  const dispatch = useDispatch()
+
+  const plusBtnClick = () => dispatch(increase())
+  const minusBtnClick = () => dispatch(decrease())
+  const resetBtnClick = () => dispatch(reset())
+
+  const props = { count, plusBtnClick, minusBtnClick, resetBtnClick}
   return (
-    <div>
-      <Header title={APP_NAME} bgColor='blue' />
-      <CountArea />
-    </div>
+    <CounterTop {...props} />
   );
 }
 

--- a/src/components/templates/top/index.stories.ts
+++ b/src/components/templates/top/index.stories.ts
@@ -1,20 +1,20 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Counter } from './index';
+import { CounterTop } from './index';
 
 
 const meta = {
-  title: 'Counter/Organisms/Counter',
-  component: Counter,
+  title: 'Counter/Templates/Top',
+  component: CounterTop,
   parameters: {
     layout: 'centered',
   },
   tags: ['autodocs'],
   argTypes: {},
-} satisfies Meta<typeof Counter>;
+} satisfies Meta<typeof CounterTop>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const CounterArea: Story = {
-  args: {count: 0},
+export const CounterTopPage: Story = {
+  args: { count: 0 },
 };

--- a/src/components/templates/top/index.tsx
+++ b/src/components/templates/top/index.tsx
@@ -1,0 +1,32 @@
+import { Header } from '../../organisms/Header';
+import { Counter as CountArea } from '../../organisms/Counter';
+import { APP_NAME } from '../../../common/constant';
+
+interface CounterTopProps {
+  /**
+   * 現在のカウント
+   */
+  count: number;
+  /**
+   * ＋ボタン押下時のイベント
+   */
+  plusBtnClick?: () => void;
+  /**
+ 　* ーボタン押下時のイベント
+ 　*/
+  minusBtnClick?: () => void;
+  /**
+　* ↺ボタン押下時のイベント
+　*/
+  resetBtnClick?: () => void;
+}
+
+export const CounterTop = (props: CounterTopProps) => {
+  return (
+    <div>
+      <Header title={APP_NAME} bgColor='blue' />
+      <CountArea {...props} />
+    </div>
+  );
+}
+


### PR DESCRIPTION
## 概要
現在のsrc/components配下は各所で正しい在り方に則っていないため、以下の修正を取り入れた

- 現在 pages で HeaderとCounterを組み合わせているが、それをtemplatesで行う
- organismsやtemplatesのstorybookではダミーデータを扱う。redux要素は扱わない
- pagesでreduxから取得した状態や実データをtemplatesに流し込む
- StorybookはUI確認用のツールのため、表示するデータはダミーデータの固定値とする
- reduxで扱う状態はサイト内全体で管理する値のみ。コンポーネント内で管理する値はreduxで管理しない

## 備考
- #1 よりも先に行うこと
- 完了次第、developにマージすること
